### PR TITLE
Fixed extracting description

### DIFF
--- a/server.js
+++ b/server.js
@@ -275,7 +275,7 @@ class LubimyCzytacProvider {
       const languages =
         $('dt:contains("Język:")').next("dd").text().trim().split(", ") || [];
       const description =
-        $(".collapse-content").html() ||
+        $("#book-description").html() ||
         $('meta[property="og:description"]').attr("content") ||
         "";
       const seriesElement = $('span.d-none.d-sm-block.mt-1:contains("Cykl:")')


### PR DESCRIPTION
The structure of the website changed, the `.collapse-content` now contains comments about the book, so it "fails silently" and does not download the correct description. Fixed the description extracting by changing the HTML attribute to `#book-description`.